### PR TITLE
feat: removed `is_buildkit_enabled` method

### DIFF
--- a/tutorjupyterlite/templates/jupyterlite/build/jupyterlite/Dockerfile
+++ b/tutorjupyterlite/templates/jupyterlite/build/jupyterlite/Dockerfile
@@ -1,8 +1,7 @@
-{% if is_buildkit_enabled() %}# syntax=docker/dockerfile:1.4{% endif %}
 From {{ JUPYTERLITE_BASE_DOCKER_IMAGE }}
 
-RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked{% endif %} \ 
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \ 
     apt update && \
     apt install -y build-essential
 


### PR DESCRIPTION
Removed `is_buildkit_enabled` since it is removed in quince version of tutor